### PR TITLE
fix(api): Updated EOS API endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           prerelease: true
 
     env:
-      REACT_APP_EOS_API_HOST: api.eosargentina.io
+      REACT_APP_EOS_API_HOST: api.eosio.cr
       REACT_APP_EOS_API_PORT: 443
       REACT_APP_EOS_API_PROTOCOL: https
       REACT_APP_EOS_CHAIN_ID: aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906


### PR DESCRIPTION
### GH Issue

Updated Endpoint due to CORS error

```
Access to fetch at 'https://api.eosargentina.io/v1/chain/get_block_header_state' from origin 'https://evodex.io' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```


### What does this PR do?

Switch endpoint to EOS Costa Rica's API endpoint

### Steps to test
1. create a transaction
1. exchange
