### PR TITLE
fix(exchange): Updated string for TX memo

### DIFF
--- a/src/utils/evolutiondex.js
+++ b/src/utils/evolutiondex.js
@@ -197,7 +197,7 @@ const exchange = async (amount, pair, ual) => {
               quantity: assetToGive.toString(),
               memo: `exchange: ${
                 pair.token
-              },${assetToReceive.toString()},send using evodex.netlify.app`
+                },${assetToReceive.toString()},sent using evodex.io`
             }
           }
         ]


### PR DESCRIPTION
### GH Issue

Memo string is not correct

![image](https://user-images.githubusercontent.com/5632966/92435526-d66ee380-f15f-11ea-8473-ed710eb6c7d9.png)

https://bloks.io/account/evolutiondex

### What does this PR do?

Updates memo string to : 

`sent using evodex.io`

### Steps to test
1. exchange tokens on evodex.io
1. check tx memo on block explorer
