### PR TITLE
Fix/remove input text

### DIFF
--- a/src/language/en/en.json
+++ b/src/language/en/en.json
@@ -50,7 +50,7 @@
     "headerTitle": "Token Listings",
     "tableLabelMyPool": "My Pools",
     "tableLabelCommunity": "Community Pools",
-    "inputLabel": "Liquidity",
+    "inputLabel": "Add / Remove",
     "available": "available",
     "add": "Add",
     "remove": "Remove",

--- a/src/language/en/en.json
+++ b/src/language/en/en.json
@@ -50,7 +50,7 @@
     "headerTitle": "Token Listings",
     "tableLabelMyPool": "My Pools",
     "tableLabelCommunity": "Community Pools",
-    "inputLabel": "You Give",
+    "inputLabel": "",
     "available": "available",
     "add": "Add",
     "remove": "Remove",

--- a/src/language/en/en.json
+++ b/src/language/en/en.json
@@ -50,7 +50,7 @@
     "headerTitle": "Token Listings",
     "tableLabelMyPool": "My Pools",
     "tableLabelCommunity": "Community Pools",
-    "inputLabel": "",
+    "inputLabel": "Liquidity",
     "available": "available",
     "add": "Add",
     "remove": "Remove",

--- a/src/language/es/es.json
+++ b/src/language/es/es.json
@@ -50,7 +50,7 @@
     "headerTitle": "Listados de tokens",
     "tableLabelMyPool": "Mis pooles",
     "tableLabelCommunity": "Pooles comunitarios",
-    "inputLabel": "Liquidez",
+    "inputLabel": "Aportar / Retirar",
     "available": "disponible",
     "add": "Agregar",
     "remove": "Retirar",

--- a/src/language/es/es.json
+++ b/src/language/es/es.json
@@ -50,7 +50,7 @@
     "headerTitle": "Listados de tokens",
     "tableLabelMyPool": "Mis pooles",
     "tableLabelCommunity": "Pooles comunitarios",
-    "inputLabel": "",
+    "inputLabel": "Liquidez",
     "available": "disponible",
     "add": "Agregar",
     "remove": "Retirar",

--- a/src/language/es/es.json
+++ b/src/language/es/es.json
@@ -50,7 +50,7 @@
     "headerTitle": "Listados de tokens",
     "tableLabelMyPool": "Mis pooles",
     "tableLabelCommunity": "Pooles comunitarios",
-    "inputLabel": "Cantidad",
+    "inputLabel": "",
     "available": "disponible",
     "add": "Agregar",
     "remove": "Retirar",


### PR DESCRIPTION
### GH Issue

Liquidity can be added ore removed, the text "You Give" is incorrect 

![image](https://user-images.githubusercontent.com/5632966/92436557-31a1d580-f162-11ea-9c9a-b70d5b48c26d.png)


### What does this PR do?

Updates Input Label  for liquidity 

### Steps to test
1. go to liquidity page
1. no input label should be showing
