### PR TITLE
fix: token convertion from token 2 to token 1

### DIFF
--- a/src/utils/evolutiondex.js
+++ b/src/utils/evolutiondex.js
@@ -180,9 +180,8 @@ const getExchangeAssets = (amount, pair) => {
 const getExchangeAssetsFromToken2 = (amount, pair) => {
   const assetToGive = numberToAsset(0, pair.from.asset.symbol)
   const assetToReceive = amountToAsset(amount, pair.to.asset)
-  const amountToReceive = assetToReceive.amount
-  amountToReceive.plus(
-    amountToReceive.multiply(pair.fee).plus(9999).divide(10000)
+  const amountToReceive = assetToReceive.amount.plus(
+    assetToReceive.amount.multiply(pair.fee).plus(9999).divide(10000)
   )
   const computeForwardAmount = computeForward(
     amountToReceive,


### PR DESCRIPTION
### GH Issue
no GH issue

### What does this PR do?
Fix a problem with the token conversion from token 1 to token 2
 
### Steps to test
1. yarn start
2. navigate to http://localhost:3000/exchange
3. type an amount for "You Receive" input

#### CheckList
- [x] Follow proper Markdown format
- [x] The content is adequate
- [x] The content is available in both english and spanish
- [x] I Ran a spell check
