### PR TITLE
fix(wallets): remove broken wallet integrations

### DIFF
--- a/src/containers/Main/Main.js
+++ b/src/containers/Main/Main.js
@@ -150,7 +150,7 @@ Main.propTypes = {
 
 Main.defaultProps = {
   openSidebar: false,
-  setOpenSidebar: () => {}
+  setOpenSidebar: () => { }
 }
 
 export default Main

--- a/src/ual.js
+++ b/src/ual.js
@@ -1,8 +1,4 @@
-import { Scatter } from 'ual-scatter'
-import { Ledger } from 'ual-ledger'
-import { Lynx } from 'ual-lynx'
 import { TokenPocket } from 'ual-token-pocket'
-import { MeetOne } from 'ual-meetone'
 import { Anchor } from 'ual-anchor'
 
 import { ualConfig } from './config'
@@ -37,11 +33,7 @@ export default {
   },
   get authenticators() {
     return [
-      new Lynx([this.network]),
-      new Ledger([this.network]),
-      new Scatter([this.network], { appName: this.appName }),
       new TokenPocket([this.network]),
-      new MeetOne([this.network.chainId]),
       new Anchor([this.network], { appName: this.appName })
     ]
   }


### PR DESCRIPTION
### GH Issue

Limit Wallet Choices #193   

### What does this PR do?

Removes `Scatter`, `Ledger`, `Lynx` and `Meet One` walets from UAL 

### Steps to test
1. Open Deploy preview link
1. Click on login
1. Only Anchor and Token Pocket should appear as choices

#### CheckList
- [x] Follow proper Markdown format
- [x] The content is adequate
- [x] The content is available in both english and spanish
- [x] I Ran a spell check
