### PR TITLE
fix(i18n): update help text translations

### DIFF
--- a/src/language/en/en.json
+++ b/src/language/en/en.json
@@ -13,7 +13,7 @@
     "addLiquidity": "Add liquidity now.",
     "exchangeStep1": "Enter a valid amount and use the dropdown menu to select the token you own and want to exchange.",
     "exchangeStep2": "Select the token you wish to receive. We will calculate this amount for you. You can use the reverse icon anytime.",
-    "feeStep1": "Here you may vote for the fee you consider to be the fairest for each token. Please, use a percentage with one decimal format. For example: 0.1%.",
+    "feeStep1": "Here you may vote for the fee you consider to be the fairest for each token. The fee must be greater than zero and no larger than 3%.  Please, use a percentage with one decimal format. For example: 0.1%.",
     "liquidityStep1": "Here you can look up the current exchange fee for each token using the dropdown menu.",
     "pool": "Pool",
     "tokenPair": "Token Pair",
@@ -71,7 +71,8 @@
     "noTokenSelected": "Please select a token to continue",
     "noAmountAdd": "Please enter the amount to add",
     "noAmountRemove": "Please enter the amount to remove",
-    "successTransaction": "Transaction successful"
+    "successTransaction": "Transaction successful",
+    "help": "Help"
   },
   "fee": {
     "title": "Vote Your Fee",
@@ -87,7 +88,8 @@
     "supply": "Supply",
     "fee": "Fee",
     "successTransaction": "Success transaction",
-    "placeholder": "This Percentage"
+    "placeholder": "This Percentage",
+    "help": "Help"
   },
   "faq": {
     "title": "FAQ's",
@@ -112,7 +114,8 @@
     "btnLabel": "exchange",
     "price": "Price",
     "yourWallet": "Your Wallet",
-    "pool": "Pool"
+    "pool": "Pool",
+    "help": "Help"
   },
   "about": {
     "title": "About evodex",

--- a/src/language/es/es.json
+++ b/src/language/es/es.json
@@ -13,11 +13,12 @@
     "addLiquidity": "Agregue liquidez ahora.",
     "exchangeStep1": "Ingrese una cantidad válida y use el menú desplegable para seleccionar el token que posee y desea intercambiar.",
     "exchangeStep2": "Seleccione el token que desea recibir. Calcularemos esta cantidad por usted. Puede utilizar el icono de retroceso en cualquier momento.",
-    "feeStep1": "Aquí puede votar por la tarifa que considere más justa para cada token. Por favor, use un porcentaje con un formato decimal. Por ejemplo: 0,1%.",
+    "feeStep1": "Aquí puede votar por la tarifa que considere más justa para cada token. La tarifa debe ser superior a cero y no superior al 3%. Por favor, use un porcentaje con un formato decimal. Por ejemplo: 0.1%.",
     "liquidityStep1": "Aquí puede buscar la tarifa de cambio actual para cada token usando el menú desplegable.",
     "pool": "Pool",
     "tokenPair": "Token",
-    "fee": "Comisión"
+    "fee": "Comisión",
+    "help": "Ayuda"
   },
   "talkUsModal": {
     "title": "Evodex es para la comunidad de EOS",
@@ -71,7 +72,8 @@
     "noTokenSelected": "Por favor seleccione un token para continuar",
     "noAmountAdd": "Por favor ingrese el monto a enviar",
     "noAmountRemove": "Por favor ingrese el monto a retirar",
-    "successTransaction": "Transacción realizada"
+    "successTransaction": "Transacción realizada",
+    "help": "Ayuda"
   },
   "fee": {
     "title": "Votar Valor de la Comisión",
@@ -87,7 +89,8 @@
     "supply": "Circulante",
     "fee": "Comisión",
     "successTransaction": "Transacción realizada",
-    "placeholder": "Este Porcentaje"
+    "placeholder": "Este Porcentaje",
+    "help": "Ayuda"
   },
   "faq": {
     "title": "Preguntas Frecuentes",
@@ -112,7 +115,8 @@
     "btnLabel": "Operar",
     "price": "Precio",
     "yourWallet": "Su Billetera",
-    "pool": "Pool"
+    "pool": "Pool",
+    "help": "Ayuda"
   },
   "about": {
     "title": "Acerca de evodex",

--- a/src/language/zh/zh.json
+++ b/src/language/zh/zh.json
@@ -13,7 +13,7 @@
     "addLiquidity": "添加流动性",
     "exchangeStep1": "输入一个数量然后选择你想要进行兑换的代币",
     "exchangeStep2": "选择你想要收到的代币，会自动计算数量，你也可以使用反转图标进行调换。",
-    "feeStep1": "在这里，你可以投票选择你认为对一个交易对来说最公平的手续费。请使用一个十进制格式的百分比。例如：0.1%。",
+    "feeStep1": "在这里，你可以投票选择你认为对一个交易对来说最公平的手续费。费用必须大于零且不大于3％ 请使用一个十进制格式的百分比。例如：0.1%",
     "liquidityStep1": "在这里，您可以使用下拉菜单查找每个交易对的当前手续费。",
     "pool": "池",
     "tokenPair": "代币列表",
@@ -71,7 +71,8 @@
     "noTokenSelected": "请选择代币以继续",
     "noAmountAdd": "请填写一个数量 添加",
     "noAmountRemove": "请填写一个数量 移除",
-    "successTransaction": "交易成功"
+    "successTransaction": "交易成功",
+    "help": "帮帮我"
   },
   "fee": {
     "title": "费率投票",
@@ -87,7 +88,8 @@
     "supply": "提供",
     "fee": "手续费",
     "successTransaction": "交易成功",
-    "placeholder": "百分比"
+    "placeholder": "百分比",
+    "help": "帮帮我"
   },
   "faq": {
     "title": "FAQ's",
@@ -112,7 +114,8 @@
     "btnLabel": "交易",
     "price": "价格",
     "yourWallet": "你的钱包",
-    "pool": "池"
+    "pool": "池",
+    "help": "帮帮我"
   },
   "about": {
     "title": "关于 evodex",

--- a/src/routes/Evodex/BackLayer/Exchange/ExchangeBackLayer.js
+++ b/src/routes/Evodex/BackLayer/Exchange/ExchangeBackLayer.js
@@ -200,7 +200,7 @@ const ExchangeBackLayer = ({
         set = setYouReceive
         break
       default:
-        set = () => {}
+        set = () => { }
     }
 
     set((prevState) => ({
@@ -450,9 +450,8 @@ const ExchangeBackLayer = ({
                   {userBalance[youGive.selectValue].poolAsset}
                   <Link
                     className={classes.poolContractLink}
-                    href={`${ualConfig.blockExplorerUrl}/account/${
-                      userBalance[youGive.selectValue].contract
-                    }`}
+                    href={`${ualConfig.blockExplorerUrl}/account/${userBalance[youGive.selectValue].contract
+                      }`}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -475,7 +474,7 @@ const ExchangeBackLayer = ({
           hasError={
             userBalance[youGive.selectValue]
               ? userBalance[youGive.selectValue].amount <
-                parseFloat(youGive.inputValue || 0)
+              parseFloat(youGive.inputValue || 0)
               : false
           }
         />
@@ -500,9 +499,8 @@ const ExchangeBackLayer = ({
                   <span>{userBalance[youReceive.selectValue].poolAsset}</span>
                   <Link
                     className={classes.poolContractLink}
-                    href={`${ualConfig.blockExplorerUrl}/account/${
-                      userBalance[youReceive.selectValue].contract
-                    }`}
+                    href={`${ualConfig.blockExplorerUrl}/account/${userBalance[youReceive.selectValue].contract
+                      }`}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -543,7 +541,7 @@ const ExchangeBackLayer = ({
           variant="body1"
           className={classes.helpText}
         >
-          HELP
+          {t('help').toUpperCase()}
         </Typography>
       </Box>
       <TourGuide

--- a/src/routes/Evodex/BackLayer/Fee/FeeBackLayer.js
+++ b/src/routes/Evodex/BackLayer/Fee/FeeBackLayer.js
@@ -278,7 +278,7 @@ const FeeBackLayer = ({
             variant="body1"
             className={classes.helpText}
           >
-            HELP
+            {t('help').toUpperCase()}
           </Typography>
         </Box>
       </Box>

--- a/src/routes/Evodex/BackLayer/Liquidity/LiquidityBackLayer.js
+++ b/src/routes/Evodex/BackLayer/Liquidity/LiquidityBackLayer.js
@@ -340,9 +340,8 @@ const LiquidityBackLayer = ({
             label={t('inputLabel')}
             helperText={
               pair
-                ? `${t('available')}: ${
-                    pair.balance ? pair.balance.toString() : 0
-                  }`
+                ? `${t('available')}: ${pair.balance ? pair.balance.toString() : 0
+                }`
                 : ''
             }
             onChange={handleOnChange}
@@ -410,7 +409,7 @@ const LiquidityBackLayer = ({
             variant="body1"
             className={classes.helpText}
           >
-            HELP
+            {t('help').toUpperCase()}
           </Typography>
         </Box>
       </Box>


### PR DESCRIPTION
### GH Issue
Add min and max fee to react tour text for vote the fee #218

### What does this PR do?

- adds translations for `HELP` link to react tour 
- Adds min max fees for vote the fee help text.


### Steps to test
1. Open Fee page
1. Change Language
1. Click on Help Text

#### CheckList
- [X] Follow proper Markdown format
- [X] The content is adequate
- [X] The content is available in both english and spanish
- [X] I Ran a spell check
