### PR TITLE
Show your wallet label only if user is login

### DIFF
--- a/src/routes/Evodex/BackLayer/Exchange/ExchangeBackLayer.js
+++ b/src/routes/Evodex/BackLayer/Exchange/ExchangeBackLayer.js
@@ -200,7 +200,7 @@ const ExchangeBackLayer = ({
         set = setYouReceive
         break
       default:
-        set = () => { }
+        set = () => {}
     }
 
     set((prevState) => ({
@@ -450,8 +450,9 @@ const ExchangeBackLayer = ({
                   {userBalance[youGive.selectValue].poolAsset}
                   <Link
                     className={classes.poolContractLink}
-                    href={`${ualConfig.blockExplorerUrl}/account/${userBalance[youGive.selectValue].contract
-                      }`}
+                    href={`${ualConfig.blockExplorerUrl}/account/${
+                      userBalance[youGive.selectValue].contract
+                    }`}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -459,22 +460,24 @@ const ExchangeBackLayer = ({
                   </Link>
                 </Typography>
               )}
-              <Typography
-                variant="body1"
-                className={clsx([classes.textInfo, classes.helperText])}
-              >
-                {pair && <span>{t('yourWallet')}: </span>}
-                {userBalance[youGive.selectValue] && (
-                  <span>{userBalance[youGive.selectValue].userAsset}</span>
-                )}
-              </Typography>
+              {ual.activeUser && (
+                <Typography
+                  variant="body1"
+                  className={clsx([classes.textInfo, classes.helperText])}
+                >
+                  {pair && <span>{t('yourWallet')}: </span>}
+                  {userBalance[youGive.selectValue] && (
+                    <span>{userBalance[youGive.selectValue].userAsset}</span>
+                  )}
+                </Typography>
+              )}
             </>
           }
           useHelperTextAsNode
           hasError={
             userBalance[youGive.selectValue]
               ? userBalance[youGive.selectValue].amount <
-              parseFloat(youGive.inputValue || 0)
+                parseFloat(youGive.inputValue || 0)
               : false
           }
         />
@@ -499,8 +502,9 @@ const ExchangeBackLayer = ({
                   <span>{userBalance[youReceive.selectValue].poolAsset}</span>
                   <Link
                     className={classes.poolContractLink}
-                    href={`${ualConfig.blockExplorerUrl}/account/${userBalance[youReceive.selectValue].contract
-                      }`}
+                    href={`${ualConfig.blockExplorerUrl}/account/${
+                      userBalance[youReceive.selectValue].contract
+                    }`}
                     target="_blank"
                     rel="noopener noreferrer"
                   >


### PR DESCRIPTION
### GH Issue

### What does this PR do?
- Show your wallet label only if user is login

### Steps to test
1. yarn start
2. go to localhost:3000
3. select the pair token that you prefer or click token pair table row 

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
